### PR TITLE
Add:プライバシーポリシーの追加 #31

### DIFF
--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,0 +1,51 @@
+<div class="privacy flex flex-col items-center">
+  <div class="p-8 md:w-4/5">
+    <h1 class="text-2xl my-16 md:text-center font-bold">プライバシーポリシー</h1>
+    <p>KnowledgeTreeQuiz（以下、「当方」といいます。）は、本ウェブサイト上で提供するサービス（以下、「本サービス」といいます。）におけるお客様の個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下、「本ポリシー」といいます。）を定めます。</p>
+  </div>
+  <div class="p-8 md:w-4/5">
+    <h3 class="text-xl font-bold py-4">お客様から取得する情報</h3>
+    <ul class="list-disc m-4">
+      <li>氏名（ニックネームやペンネームも含む）</li>
+      <li>メールアドレス</li>
+      <li>外部サービスのプライバシー設定によりお客様が連携先に開示を認めた情報</li>
+      <li>Cookie（クッキー）を用いて生成された識別情報</li>
+      <li>本サービスの滞在時間、入力履歴等の行動履歴</li>
+    </ul>
+  </div>
+  <div class="p-8 md:w-4/5">
+    <h3 class="text-xl font-bold py-4">お客様の情報を利用する目的</h3>
+    <p>本サービスは、お客様から取得した情報を、以下の目的のために利用します。</p>
+    <ul class="list-disc m-4">
+      <li>本サービスに関する登録の受付、お客様の本人確認、認証のため</li>
+      <li>お客様の本サービスの利用履歴を管理するため</li>
+      <li>本サービスにおけるお客様の行動履歴を分析し、本サービスの維持改善に役立てるため</li>
+      <li>お客様からのお問い合わせに対応するため</li>
+      <li>本サービスの利用規約や法令に違反する行為に対応するため</li>
+      <li>本サービスの変更、提供中止、終了、契約解除を連絡するため</li>
+      <li>本サービス規約の変更等を通知するため</li>
+      <li>以上の他、当方サービスの提供、維持、保護及び改善のため</li>
+    </ul>
+  </div>
+  <div class="p-8 md:w-4/5">
+    <h3 class="text-xl font-bold py-4">第三者提供</h3>
+    <p>お客様から取得した個人情報を、個人情報保護法その他の法令に基づき開示が認められる場合を除き、お客様ご本人の同意を得ずに第三者に提供することはありません。</p>
+  </div>
+  <div class="p-8 md:w-4/5">
+    <h3 class="text-xl font-bold py-4">アクセス解析ツールについて</h3>
+    <p>当サービスは、Googleが提供するアクセス解析ツール「Googleアナリティクス」を利用しています。Googleアナリティクスは、Cookieを使用することでお客様のトラフィックデータを収集しています。お客様はブラウザの設定でCookieを無効にすることで、トラフィックデータの収集を拒否することができます。詳しくは<%= link_to 'Google アナリティクス利用規約', 'https://marketingplatform.google.com/about/analytics/terms/jp/', class: 'analytics', class: 'text-blue-500', target: '_blank', rel: 'noopener noreferrer' %>をご確認ください。</p>
+  </div>
+  <div class="p-8 md:w-4/5">
+    <h3 class="text-xl font-bold py-4">プライバシーポリシーの変更</h3>
+    <p>当方は、必要に応じて、本ポリシーの内容を変更します。本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、お客様に通知することなく、変更することができるものとします。当方が別途定める場合を除いて、変更後のプライバシーポリシーは、本サービス中のウェブページに掲載したときから効力を生じるものとします。</p>
+  </div>
+  <div class="p-8 md:w-4/5">
+    <h3 class="text-xl font-bold py-4">お問合せ</h3>
+    <p>お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、以下のお問い合わせフォームからご連絡ください。</p>
+    <p class='py-2'><%= link_to 'お問い合わせフォーム', 'https://forms.gle/kdcCEY96Eo3dzrB76', class: "link" %></p>
+  </div>
+  <div class="p-8 md:w-4/5">
+    <h2 class="text-end">以上</h2>
+    <h2 class="my-4 text-end">2023年7月1日制定</h2>
+  </div>
+</div>


### PR DESCRIPTION
gem 'high_voltage'を使用してプライバシーポリシーページを追加しました。
確認の際は、「localhost:3000/pages/privacy_policy」でお願いします。

参考( 'high_voltage'gemのgithub)
https://github.com/thoughtbot/high_voltage