### PR TITLE
refactor:google_login_apiコントローラー #70

### DIFF
--- a/app/controllers/google_login_api_controller.rb
+++ b/app/controllers/google_login_api_controller.rb
@@ -1,21 +1,47 @@
 class GoogleLoginApiController < ApplicationController
-  require 'googleauth/id_tokens/verifier'
+  require "googleauth/id_tokens/verifier"
 
   protect_from_forgery except: :callback
   before_action :verify_g_csrf_token
 
   def callback
-    payload = Google::Auth::IDTokens.verify_oidc(params[:credential], aud: ENV["GOOGLE_CLIENT_ID"])
-    user = User.find_or_create_by(email: payload['email'])
-    session[:user_id] = user.id
-    redirect_to quizzes_path, notice: 'ログインしました'
+    verify_token_and_redirect
   end
 
   private
 
+  def verify_token_and_redirect
+    payload = verify_oidc_token
+    user = find_or_create_user(payload)
+    user_session(user)
+    redirect_to quizzes_path, notice: t(".success")
+  end
+
+  def verify_oidc_token
+    Google::Auth::IDTokens.verify_oidc(params[:credential], aud: ENV.fetch("GOOGLE_CLIENT_ID"))
+  end
+
+  def find_or_create_user(payload)
+    User.find_or_create_by(email: payload["email"])
+  end
+
+  def user_session(user)
+    session[:user_id] = user.id
+  end
+
   def verify_g_csrf_token
-    if cookies["g_csrf_token"].blank? || params[:g_csrf_token].blank? || cookies["g_csrf_token"] != params[:g_csrf_token]
-      redirect_to root_path, notice: '不正なアクセスです'
-    end
+    redirect_to root_path, notice: t(".fail") if csrf_token_invalid?
+  end
+
+  def csrf_token_invalid?
+    missing_token? || invalid_token?
+  end
+
+  def missing_token?
+    cookies["g_csrf_token"].blank? || params[:g_csrf_token].blank?
+  end
+
+  def invalid_token?
+    cookies["g_csrf_token"] != params[:g_csrf_token]
   end
 end

--- a/app/controllers/google_login_api_controller.rb
+++ b/app/controllers/google_login_api_controller.rb
@@ -1,3 +1,4 @@
+# 参考記事 https://zenn.dev/yoiyoicho/articles/c44a80e4bb4515
 class GoogleLoginApiController < ApplicationController
   require "googleauth/id_tokens/verifier"
 

--- a/app/controllers/google_login_api_controller.rb
+++ b/app/controllers/google_login_api_controller.rb
@@ -1,48 +1,63 @@
 # 参考記事 https://zenn.dev/yoiyoicho/articles/c44a80e4bb4515
 class GoogleLoginApiController < ApplicationController
+  # GoogleのIDトークンを検証するためのライブラリを読み込みます
   require "googleauth/id_tokens/verifier"
 
+  # CSRF攻撃から保護しますが、callbackアクションは除外します
   protect_from_forgery except: :callback
+  # 各アクションの前に、GoogleのCSRFトークンを検証します
   before_action :verify_g_csrf_token
 
   def callback
+    # トークンを検証し、ユーザーを見つけてセッションを設定し、リダイレクトします
     verify_token_and_redirect
   end
 
   private
 
   def verify_token_and_redirect
+    # GoogleのOIDCトークンを検証します
     payload = verify_oidc_token
+    # ペイロードからユーザーを見つけるか作成します
     user = find_or_create_user(payload)
+    # ユーザーのセッションを設定します
     user_session(user)
+    # クイズのページにリダイレクトします
     redirect_to quizzes_path, notice: t(".success")
   end
 
   def verify_oidc_token
+    # GoogleのOIDCトークンを検証します
     Google::Auth::IDTokens.verify_oidc(params[:credential], aud: ENV.fetch("GOOGLE_CLIENT_ID"))
   end
 
   def find_or_create_user(payload)
+    # ペイロードからユーザーを見つけるか作成します
     User.find_or_create_by(email: payload["email"])
   end
 
   def user_session(user)
+    # ユーザーのセッションを設定します
     session[:user_id] = user.id
   end
 
   def verify_g_csrf_token
+    # CSRFトークンが無効な場合、ルートパスにリダイレクトします
     redirect_to root_path, notice: t(".fail") if csrf_token_invalid?
   end
 
   def csrf_token_invalid?
+    # CSRFトークンが欠落しているか無効であるかを確認します
     missing_token? || invalid_token?
   end
 
   def missing_token?
+    # CSRFトークンが欠落しているかを確認します
     cookies["g_csrf_token"].blank? || params[:g_csrf_token].blank?
   end
 
   def invalid_token?
+    # CSRFトークンが無効であるかを確認します
     cookies["g_csrf_token"] != params[:g_csrf_token]
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -21,3 +21,8 @@ ja:
       login: "ログイン"
       to_register_page: "登録ページへ"
       password_forget: "パスワードをお忘れの方はこちら"
+  google_login_api:
+    callback:
+      success: "ログインしました"
+    verify_g_csrf_token:
+      fail: "不正なアクセスです"


### PR DESCRIPTION
google_login_apiコントローラーのリファクタリングをしました。

・シングルクォーテーション→ダブルクォーテーションに変更
・i18n対応
・callbackメソッドとverify_g_csrf_tokenメソッド→メソッドを短く、シンプルに分割

上記の対応をしました。メソッドはかなり細かく分解されているので、コードの内容と挙動の確認をお願いします。