### PR TITLE
Refactor/rich editor #155

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -41,3 +41,7 @@ trix-editor {
   rows: 10;
   overflow-y: auto;
 }
+
+.trix-button--icon-attach {
+  display: none !important;
+}

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -11,6 +11,8 @@ class Quiz < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true
   validates :explanation, presence: true
+  validates :category, presence: true
+  validates :level, presence: true
 
   validate :at_least_two_choices
   validate :at_least_one_correct_choice


### PR DESCRIPTION
リッチエディターの画像ボタンを非表示（応急処置）

問題として、
1. クリップボタンが「|」として表示されてしまう。
<img width="97" alt="スクリーンショット 2023-07-21 12 33 41" src="https://github.com/furukawaeiichi/QUIZ_APP/assets/102509805/823f5aa6-348e-4935-a1b2-95c4f01a1167">
<img width="36" alt="スクリーンショット 2023-07-21 12 35 23" src="https://github.com/furukawaeiichi/QUIZ_APP/assets/102509805/d162b1f2-c2fe-4c6f-bb9e-1d53b08b66eb">


2. ドラッグ＆ドロップで画像を貼り付けることはできてしまう。

https://github.com/furukawaeiichi/QUIZ_APP/assets/102509805/1cf5ab2a-5660-4b23-bd9b-399312dea77d

他の解決策あれば試してみてほしいです。
https://qiita.com/MIDO-ruby7/items/fd2c31ba00d8420cf630#%E3%83%9C%E3%82%BF%E3%83%B3%E3%81%AE%E5%89%8A%E9%99%A4