### PR TITLE
ダークモードへの切り替えができないバグの修正 #190

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,12 +3,5 @@ import "@hotwired/turbo-rails";
 import "./controllers";
 import "trix";
 import "@rails/actiontext";
+import "./custom/dark"
 import "./custom/tourguide"
-
-document.addEventListener("turbo:load", () => {
-  const toggleDarkMode = document.querySelector("#toggle-dark-mode");
-
-  toggleDarkMode.addEventListener("click", () => {
-    document.documentElement.classList.toggle("dark");
-  });
-});

--- a/app/javascript/custom/dark.js
+++ b/app/javascript/custom/dark.js
@@ -1,0 +1,7 @@
+document.addEventListener("turbo:load", () => {
+  const toggleDarkMode = document.querySelector("#toggle-dark-mode");
+
+  toggleDarkMode.addEventListener("click", () => {
+    document.documentElement.classList.toggle("dark");
+  });
+});


### PR DESCRIPTION
JavaScriptの読み込み順を変更。ダークモードへの切り替えがツアーガイドより先に読み込まれるようにした。